### PR TITLE
remove NAT Gateway & Elastic IP

### DIFF
--- a/cdk/lib/cdk-stack.ts
+++ b/cdk/lib/cdk-stack.ts
@@ -39,11 +39,6 @@ export class CdkStack extends cdk.Stack {
           subnetType: ec2.SubnetType.PUBLIC,
           cidrMask: 26,
         },
-        {
-          name: `${prefix}PrivateSn`,
-          subnetType: ec2.SubnetType.PRIVATE,
-          cidrMask: 26,
-        },
       ],
     });
     const securityGroup = new ec2.SecurityGroup(this, `${prefix}SecurityGroup`, {
@@ -97,7 +92,10 @@ export class CdkStack extends cdk.Stack {
           name: 'FOO',
           value: 'bar',
         }]
-      }]
+      }],
+      subnetSelection: {
+        subnetType: ec2.SubnetType.PUBLIC,
+      }
     }));
   }
 }


### PR DESCRIPTION
They are wasteful for this app and they are too expensive.

To achieve this goal, the private subnet is deleted.
`subnetSelection` setting is needed because an error below occurs without it.

```
There are no 'Private' subnet groups in this VPC. Available types: Public
```

c.f. [interface EcsTaskProps · AWS CDK](https://docs.aws.amazon.com/cdk/api/latest/docs/@aws-cdk_aws-events-targets.EcsTaskProps.html#subnetselection)
```
Type: SubnetSelection (optional, default: Private subnets)
```